### PR TITLE
Improve server connection behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,28 +40,22 @@ python test_client.py
 
 ## WebSocket Protocol
 
-The server operates on WebSocket protocol (port 8888). When a client connects to `ws://localhost:8888/ws`, the server automatically generates and returns a unique device ID. This ID is used for all subsequent commands.
+The server operates on WebSocket protocol (port 8888). When a client connects to `ws://localhost:8888/ws`, a connection is created where the client can execute commands like `CreateDevice` to start using the Spotify Connect device or commands like `Load` to start interacting with an specific device.
 
 ### Connection Flow
 
 1. Client connects to `ws://localhost:8888/ws`
-2. Server generates and sends a device ID:
+2. Server responds with a success or error message. In case of success, providing the protocol version.
 ```json
 {
-    "device_id": "generated_uuid",
-    "message": "Connected to server. Use this device_id for future commands."
+  "status": "Connected to server",
+  "protocol_version": "1.0.0"
 }
 ```
-3. Client uses this device ID for all future commands
+3. Now the client can start executing commands.
 
 ### Available Commands
-
-- Connect: Initialize a Spotify Connect device with an access token
-- Play: Play a specific track
-- Pause: Pause playback
-- Resume: Resume playback
-- Stop: Stop playback
-- GetCurrentTrack: Get information about the current track (coming soon)
+- CreateDevice: Initialize a Spotify Connect device with an access token
 
 ### Command Format
 
@@ -69,37 +63,28 @@ All commands follow this JSON structure:
 
 ```json
 {
-    "Command_Name": {
-        "device_id": "device_id_from_server",
-        ...command specific fields...
+    "command_type": "Name",
+    "params": {
+        "key": "value"
     }
 }
 ```
 
-Example commands:
+For example:
 
 ```json
-// Connect to Spotify
 {
-    "Connect": {
-        "token": "spotify_access_token",
-        "device_id": "device_id_from_server",
-        "device_name": "Optional Device Name"
-    }
-}
-
-// Play a track
-{
-    "Play": {
-        "device_id": "device_id_from_server",
-        "track_id": "spotify_track_id"
-    }
+  "command_type": "CreateDevice",
+  "params": {
+    "device_name": "Blockify Boombox #2",
+    "token": "yQRB....MEg3"
+  }
 }
 ```
 
 ### Server Responses
 
-All server responses follow this format:
+All server responses to commands follow this format:
 ```json
 {
     "success": true/false,
@@ -107,17 +92,6 @@ All server responses follow this format:
     "data": {} // Optional additional data
 }
 ```
-
-## Project Structure
-
-- `src/`
-  - `main.rs`: Server entry point
-  - `server.rs`: WebSocket server and command handling
-  - `spotify.rs`: Spotify Connect device implementation
-  - `commands.rs`: Command and response types
-- `test_client.py`: Python test client
-- `Cargo.toml`: Rust dependencies and project metadata
-
 ## License
 
 MIT License

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -11,7 +11,7 @@ pub struct CommandMessage {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(tag = "type")]
 pub enum Command {
-    Connect {
+    CreateDevice {
         token: String,
         device_name: Option<String>,
     },
@@ -30,7 +30,7 @@ impl Command {
         let device_id = msg.device_id;
         
         let command = match msg.command_type.as_str() {
-            "connect" => {
+            "CreateDevice" => {
                 let token = msg.params.get("token")
                     .and_then(|v| v.as_str())
                     .ok_or("Missing token parameter")?
@@ -40,7 +40,7 @@ impl Command {
                     .and_then(|v| v.as_str())
                     .map(String::from);
                 
-                Command::Connect { token, device_name }
+                Command::CreateDevice { token, device_name }
             },
             "play" => {
                 let track_id = msg.params.get("track_id")

--- a/src/server.rs
+++ b/src/server.rs
@@ -138,7 +138,7 @@ impl SpotifyServer {
             let mut clients = server.clients.lock().await;
 
             match command {
-                Command::Connect { token, device_name } => {
+                Command::CreateDevice { token, device_name } => {
                     if let Some(client) = clients.get_mut(device_id) {
                         if client.spotify.is_some() {
                             CommandResponse::error("Device is already connected to Spotify")

--- a/src/server.rs
+++ b/src/server.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 use warp::ws::{Message, WebSocket};
 use warp::Filter;
 
-const PROTOCOL_VERSION: &str = "1.0.0";
+const PROTOCOL_VERSION: &str = "0.1.0";
 
 type Clients = Arc<Mutex<HashMap<String, Client>>>;
 pub type WsResult<T> = std::result::Result<T, warp::Error>;

--- a/src/server.rs
+++ b/src/server.rs
@@ -186,11 +186,3 @@ impl SpotifyServer {
 fn with_clients(clients: Clients) -> impl Filter<Extract = (Clients,), Error = Infallible> + Clone {
     warp::any().map(move || clients.clone())
 }
-
-async fn broadcast_to_client(clients: &Clients, device_id: &str, message: &str) {
-    if let Some(client) = clients.lock().await.get(device_id) {
-        if let Err(e) = client.sender.send(Ok(Message::text(message))) {
-            error!("Error broadcasting to device {}: {}", device_id, e);
-        }
-    }
-}

--- a/src/server.rs
+++ b/src/server.rs
@@ -12,13 +12,15 @@ use uuid::Uuid;
 use warp::ws::{Message, WebSocket};
 use warp::Filter;
 
+const PROTOCOL_VERSION: &str = "1.0.0";
+
 type Clients = Arc<Mutex<HashMap<String, Client>>>;
 pub type WsResult<T> = std::result::Result<T, warp::Error>;
 
 #[derive(Debug, serde::Serialize)]
 struct ConnectionResponse {
-    device_id: String,
-    message: String,
+    status: String,
+    protocol_version: String,
 }
 
 struct Client {
@@ -35,28 +37,39 @@ impl Client {
     }
 }
 
+struct ConnectionState {
+    devices: HashMap<String, SpotifyClient>,
+    sender: mpsc::UnboundedSender<WsResult<Message>>,
+}
+
+impl ConnectionState {
+    fn new(sender: mpsc::UnboundedSender<WsResult<Message>>) -> Self {
+        Self {
+            devices: HashMap::new(),
+            sender,
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct SpotifyServer {
-    clients: Clients,
     command_manager: CommandManager,
 }
 
 impl SpotifyServer {
     pub fn new() -> Self {
         Self {
-            clients: Arc::new(Mutex::new(HashMap::new())),
             command_manager: CommandManager::new(),
         }
     }
 
     pub async fn start(self, port: u16) {
-        let clients = self.clients.clone();
-
+        let server = self.clone();
         let ws_route = warp::path("ws")
             .and(warp::ws())
-            .and(with_clients(clients.clone()))
-            .map(|ws: warp::ws::Ws, clients| {
-                ws.on_upgrade(move |socket| Self::handle_client_connection(socket, clients))
+            .map(move |ws: warp::ws::Ws| {
+                let server = server.clone();
+                ws.on_upgrade(move |socket| server.handle_client_connection(socket))
             });
 
         let routes = ws_route.with(warp::cors().allow_any_origin());
@@ -64,9 +77,8 @@ impl SpotifyServer {
         warp::serve(routes).run(([127, 0, 0, 1], port)).await;
     }
 
-    async fn handle_client_connection(ws: WebSocket, clients: Clients) {
-        let device_id = Uuid::new_v4().to_string();
-        info!("New client connecting with generated device_id: {}", device_id);
+    async fn handle_client_connection(self, ws: WebSocket) {
+        info!("New client connecting");
 
         let (ws_sender, mut ws_receiver) = ws.split();
         let (tx, rx) = mpsc::unbounded_channel();
@@ -78,98 +90,80 @@ impl SpotifyServer {
             }
         }));
 
-        {
-            let mut clients = clients.lock().await;
-            clients.insert(device_id.clone(), Client::new(tx.clone()));
-        }
-
+        // Create connection-specific state
+        let connection_state = Arc::new(Mutex::new(ConnectionState::new(tx.clone())));
+        
         let connection_response = ConnectionResponse {
-            device_id: device_id.clone(),
-            message: "Connected to server. Use this device_id for future commands.".to_string(),
+            status: "Connected to server".to_string(),
+            protocol_version: PROTOCOL_VERSION.to_string(),
         };
         
         if let Ok(response_json) = serde_json::to_string(&connection_response) {
             if let Err(e) = tx.send(Ok(Message::text(response_json))) {
-                error!("Error sending initial device_id: {}", e);
+                error!("Error sending initial connection response: {}", e);
                 return;
             }
         }
-
-        let server = SpotifyServer { clients: clients.clone(), command_manager: CommandManager::new() };
         
         while let Some(result) = ws_receiver.next().await {
             let msg = match result {
                 Ok(msg) => msg,
                 Err(e) => {
-                    error!("Error receiving ws message for device_id {}: {}", device_id, e);
+                    error!("Error receiving ws message: {}", e);
                     break;
                 }
             };
 
             if let Ok(text) = msg.to_str() {
-                if let Err(e) = Self::process_ws_message(text, &device_id, &tx, &server).await {
+                if let Err(e) = self.process_ws_message(text, &tx, connection_state.clone()).await {
                     error!("Error processing message: {}", e);
                     break;
                 }
             }
         }
 
-        clients.lock().await.remove(&device_id);
-        info!("Client {} disconnected", device_id);
+        info!("Client disconnected");
     }
 
     async fn process_ws_message(
+        &self,
         text: &str,
-        device_id: &str,
         tx: &mpsc::UnboundedSender<WsResult<Message>>,
-        server: &SpotifyServer,
+        connection_state: Arc<Mutex<ConnectionState>>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let command_message: CommandMessage = serde_json::from_str(text)?;
-        let (msg_device_id, command) = Command::from_message(command_message)?;
+        let (device_id, command) = Command::from_message(command_message)?;
 
-        // Verify the device ID matches
-        if msg_device_id != device_id {
-            let error_response = CommandResponse::error("Device ID mismatch");
-            tx.send(Ok(Message::text(serde_json::to_string(&error_response)?)))?;
-            return Ok(());
-        }
+        info!("Processing command: {:?}", command); 
 
         let response = {
-            let mut clients = server.clients.lock().await;
+            let mut state = connection_state.lock().await;
 
             match command {
                 Command::CreateDevice { token, device_name } => {
-                    if let Some(client) = clients.get_mut(device_id) {
-                        if client.spotify.is_some() {
-                            CommandResponse::error("Device is already connected to Spotify")
-                        } else {
-                            let mut spotify = SpotifyClient::new();
-                            match spotify
-                                .initialize(
-                                    &token,
-                                    device_name.unwrap_or_else(|| format!("Blockyspot {device_id}")),
-                                    client.sender.clone(),
-                                )
-                                .await
-                            {
-                                Ok(()) => {
-                                    client.spotify = Some(spotify);
-                                    CommandResponse::success("Connected to Spotify", None)
-                                }
-                                Err(e) => CommandResponse::error(format!("Failed to connect: {e}")),
-                            }
-                        }
+                    if state.devices.contains_key(&device_id) {
+                        CommandResponse::error("Device ID already exists")
                     } else {
-                        CommandResponse::error("Device not found")
+                        let mut spotify = SpotifyClient::new();
+                        match spotify
+                            .initialize(
+                                &token,
+                                device_name.unwrap_or_else(|| format!("Blockyspot {device_id}")),
+                                tx.clone(),
+                            )
+                            .await
+                        {
+                            Ok(()) => {
+                                state.devices.insert(device_id, spotify);
+                                CommandResponse::success("Connected to Spotify", None)
+                            }
+                            Err(e) => CommandResponse::error(format!("Failed to connect: {e}")),
+                        }
                     }
                 }
                 cmd => {
-                    if let Some(client) = clients.get_mut(device_id) {
-                        if let Some(spotify) = &mut client.spotify {
-                            server.command_manager.execute(cmd, spotify)
-                        } else {
-                            CommandResponse::error("Device not connected to Spotify")
-                        }
+                    if let Some(spotify) = state.devices.get_mut(&device_id) {
+                        self.command_manager.execute(cmd, spotify)
                     } else {
                         CommandResponse::error("Device not found")
                     }
@@ -181,8 +175,4 @@ impl SpotifyServer {
         tx.send(Ok(Message::text(response_json)))?;
         Ok(())
     }
-}
-
-fn with_clients(clients: Clients) -> impl Filter<Extract = (Clients,), Error = Infallible> + Clone {
-    warp::any().map(move || clients.clone())
 }

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -165,9 +165,6 @@ impl SpotifyClient {
 
         let spirc = Arc::new(spirc);
 
-        // Queue the commands
-        spirc.activate()?;
-
         self.session = Some(session);
         self.player = Some(player);
         self.spirc = Some(spirc);


### PR DESCRIPTION
# Summary
This pull request makes big breaking changes in the way the user connects and interacts with the server. This changes were necessary to make the API useful for most use cases, now allowing creating mulltiple Spotify Connect devices and easily interacting with them.

Now devices aren't created on initial connection but on command, which is the feature that allows the multiple device creation, and users only have to worry for the IDs of their devices and not any other connection identifier because each connection has its own state instead of a global one (f4355cd19a87c7acd3a434c0e4137f68bcca50a2).
# Previous behaviour
Users had to connect to `ws:127.0.0.1:8888/ws` and then the server created a `device_id` for them, which would be the one they would use to create their actual device and interact with them via commands. The user would have to execute the `Connect` command in order to send the token credentials and the device name to create the device. On top of those parameters, the user would also have to provide its device_id, even though you could only have one device. This was a redundancy and only worked as an identifier for the connection.
# New behaviour
Now, when the user connects to `ws:127.0.0.1:8888/ws`, the server responds with a nessage similar to this:
```json
{
  "status": "Connected to server",
  "protocol_version": "1.0.0"
}
```

The user can then send the `CreateDevice` command providing an `access_token` and an optional `device_name`. The server then responds with a message similar to this:
```json
{
  "success": true,
  "message": "Connected to Spotify",
  "data": {
    "device_id": "8b10e92d-c1d9-4c3a-acd4-478e2ac0bef5"
  }
}
```

The user can execute this command as many times asa they want and they only have to keep track of the devices IDs to execute commands in them.

# Specififc changes
- Server was refactored: now is more clean and functionalities are splitted in different functions 5d0c113de26da2fbe945e83fb38b3ef86be8c037 & ebc1fc8703ea7fda5daddea26668daf7f2a25ac8
- `Connect` command was renamed to `CreateDevice` 9c68d22d91d1a1a04e3c16de8a4408d38bd5cb08
- `device_id` is no longer created on initial connection for clients f4355cd19a87c7acd3a434c0e4137f68bcca50a2
- To create a new device you need to use the `CreateDevice command` 12ca4841f187db10420971284dab90bca31a6a40
- Newly created Spirc clients don't activate by default 9f58be317422513b13edd283b10d0233ed646321
- A protocol version constant has been added to keep systems synchronized 23cd1ec0f79c0a718ab28a6f8d8dfef8b2630439