### PR TITLE
Error handling

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -49,9 +49,6 @@ impl Command {
                 (String::new(), Command::CreateDevice { token, device_name })
             },
             cmd_type => {
-                let device_id = msg.device_id
-                    .ok_or("Device ID is required for this command")?;
-                
                 let command = match cmd_type {
                     "Play" => Command::Play,
                     "PlayPause" => Command::PlayPause,
@@ -100,6 +97,9 @@ impl Command {
                     "Activate" => Command::Activate,
                     _ => return Err(format!("Unknown command type: {}", cmd_type))
                 };
+                
+                let device_id = msg.device_id
+                    .ok_or("Device ID is required for this command")?;
                 
                 (device_id, command)
             }


### PR DESCRIPTION
This pull request fixes some issues that broke the connection with the client when this sent a bad request.

The issues #4 and #5 were fixed in 46c5f71198967989b82fa97822a7adaa69f130b6. 
Also, a bug from this fix that made the server ask for a device_id to invalid commands was fixed in b32cd075321e4c70395ad79ced93180d1dca8c9e.

Resolves #5, resolves #4
