### PR TITLE
Add new command system

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,28 +40,22 @@ python test_client.py
 
 ## WebSocket Protocol
 
-The server operates on WebSocket protocol (port 8888). When a client connects to `ws://localhost:8888/ws`, the server automatically generates and returns a unique device ID. This ID is used for all subsequent commands.
+The server operates on WebSocket protocol (port 8888). When a client connects to `ws://localhost:8888/ws`, a connection is created where the client can execute commands like `CreateDevice` to start using the Spotify Connect device or commands like `Load` to start interacting with an specific device.
 
 ### Connection Flow
 
 1. Client connects to `ws://localhost:8888/ws`
-2. Server generates and sends a device ID:
+2. Server responds with a success or error message. In case of success, providing the protocol version.
 ```json
 {
-    "device_id": "generated_uuid",
-    "message": "Connected to server. Use this device_id for future commands."
+  "status": "Connected to server",
+  "protocol_version": "1.0.0"
 }
 ```
-3. Client uses this device ID for all future commands
+3. Now the client can start executing commands.
 
 ### Available Commands
-
-- Connect: Initialize a Spotify Connect device with an access token
-- Play: Play a specific track
-- Pause: Pause playback
-- Resume: Resume playback
-- Stop: Stop playback
-- GetCurrentTrack: Get information about the current track (coming soon)
+- CreateDevice: Initialize a Spotify Connect device with an access token
 
 ### Command Format
 
@@ -69,37 +63,28 @@ All commands follow this JSON structure:
 
 ```json
 {
-    "Command_Name": {
-        "device_id": "device_id_from_server",
-        ...command specific fields...
+    "command_type": "Name",
+    "params": {
+        "key": "value"
     }
 }
 ```
 
-Example commands:
+For example:
 
 ```json
-// Connect to Spotify
 {
-    "Connect": {
-        "token": "spotify_access_token",
-        "device_id": "device_id_from_server",
-        "device_name": "Optional Device Name"
-    }
-}
-
-// Play a track
-{
-    "Play": {
-        "device_id": "device_id_from_server",
-        "track_id": "spotify_track_id"
-    }
+  "command_type": "CreateDevice",
+  "params": {
+    "device_name": "Blockify Boombox #2",
+    "token": "yQRB....MEg3"
+  }
 }
 ```
 
 ### Server Responses
 
-All server responses follow this format:
+All server responses to commands follow this format:
 ```json
 {
     "success": true/false,
@@ -107,17 +92,6 @@ All server responses follow this format:
     "data": {} // Optional additional data
 }
 ```
-
-## Project Structure
-
-- `src/`
-  - `main.rs`: Server entry point
-  - `server.rs`: WebSocket server and command handling
-  - `spotify.rs`: Spotify Connect device implementation
-  - `commands.rs`: Command and response types
-- `test_client.py`: Python test client
-- `Cargo.toml`: Rust dependencies and project metadata
-
 ## License
 
 MIT License

--- a/src/command_manager.rs
+++ b/src/command_manager.rs
@@ -2,20 +2,119 @@ use crate::spotify::SpotifyClient;
 use crate::commands::{Command, CommandResponse};
 
 pub trait CommandHandler {
-    fn handle(client: &SpotifyClient, args: CommandArgs) -> CommandResponse;
+    fn handle(client: &SpotifyClient, command: &Command) -> CommandResponse;
 }
 
 #[derive(Debug)]
 pub struct CommandArgs {
-    pub data: serde_json::Value,
+    pub command: Command,
 }
 
-pub struct PauseCommandHandler;
-impl CommandHandler for PauseCommandHandler {
-    fn handle(client: &SpotifyClient, _args: CommandArgs) -> CommandResponse {
-        match client.pause() {
-            Ok(()) => CommandResponse::success("Playback paused", None),
-            Err(e) => CommandResponse::error(format!("Failed to pause: {}", e)),
+macro_rules! impl_simple_handler {
+    ($name:ident, $method:ident, $success_msg:expr) => {
+        pub struct $name;
+        impl CommandHandler for $name {
+            fn handle(client: &SpotifyClient, _command: &Command) -> CommandResponse {
+                match client.$method() {
+                    Ok(()) => CommandResponse::success($success_msg, None),
+                    Err(e) => CommandResponse::error(format!("Failed to {}: {}", stringify!($method), e)),
+                }
+            }
+        }
+    };
+}
+
+impl_simple_handler!(PlayCommandHandler, play, "Playback started");
+impl_simple_handler!(PlayPauseCommandHandler, play_pause, "Playback toggled");
+impl_simple_handler!(PauseCommandHandler, pause, "Playback paused");
+impl_simple_handler!(PrevCommandHandler, prev, "Previous track");
+impl_simple_handler!(NextCommandHandler, next, "Next track");
+impl_simple_handler!(VolumeUpCommandHandler, volume_up, "Volume increased");
+impl_simple_handler!(VolumeDownCommandHandler, volume_down, "Volume decreased");
+impl_simple_handler!(ShutdownCommandHandler, shutdown, "Device shutdown");
+impl_simple_handler!(ActivateCommandHandler, activate, "Device activated");
+
+// Handlers for commands with parameters
+pub struct ShuffleCommandHandler;
+impl CommandHandler for ShuffleCommandHandler {
+    fn handle(client: &SpotifyClient, command: &Command) -> CommandResponse {
+        if let Command::Shuffle(state) = command {
+            match client.shuffle(*state) {
+                Ok(()) => CommandResponse::success(format!("Shuffle {}", if *state { "enabled" } else { "disabled" }), None),
+                Err(e) => CommandResponse::error(format!("Failed to set shuffle: {}", e)),
+            }
+        } else {
+            CommandResponse::error("Invalid shuffle command")
+        }
+    }
+}
+
+pub struct RepeatCommandHandler;
+impl CommandHandler for RepeatCommandHandler {
+    fn handle(client: &SpotifyClient, command: &Command) -> CommandResponse {
+        if let Command::Repeat(state) = command {
+            match client.repeat(*state) {
+                Ok(()) => CommandResponse::success(format!("Repeat {}", if *state { "enabled" } else { "disabled" }), None),
+                Err(e) => CommandResponse::error(format!("Failed to set repeat: {}", e)),
+            }
+        } else {
+            CommandResponse::error("Invalid repeat command")
+        }
+    }
+}
+
+pub struct RepeatTrackCommandHandler;
+impl CommandHandler for RepeatTrackCommandHandler {
+    fn handle(client: &SpotifyClient, command: &Command) -> CommandResponse {
+        if let Command::RepeatTrack(state) = command {
+            match client.repeat_track(*state) {
+                Ok(()) => CommandResponse::success(format!("Track repeat {}", if *state { "enabled" } else { "disabled" }), None),
+                Err(e) => CommandResponse::error(format!("Failed to set track repeat: {}", e)),
+            }
+        } else {
+            CommandResponse::error("Invalid repeat track command")
+        }
+    }
+}
+
+pub struct DisconnectCommandHandler;
+impl CommandHandler for DisconnectCommandHandler {
+    fn handle(client: &SpotifyClient, command: &Command) -> CommandResponse {
+        if let Command::Disconnect { pause } = command {
+            match client.disconnect(*pause) {
+                Ok(()) => CommandResponse::success("Device disconnected", None),
+                Err(e) => CommandResponse::error(format!("Failed to disconnect: {}", e)),
+            }
+        } else {
+            CommandResponse::error("Invalid disconnect command")
+        }
+    }
+}
+
+pub struct SetPositionCommandHandler;
+impl CommandHandler for SetPositionCommandHandler {
+    fn handle(client: &SpotifyClient, command: &Command) -> CommandResponse {
+        if let Command::SetPosition(position) = command {
+            match client.set_position_ms(*position) {
+                Ok(()) => CommandResponse::success("Position updated", None),
+                Err(e) => CommandResponse::error(format!("Failed to set position: {}", e)),
+            }
+        } else {
+            CommandResponse::error("Invalid set position command")
+        }
+    }
+}
+
+pub struct SetVolumeCommandHandler;
+impl CommandHandler for SetVolumeCommandHandler {
+    fn handle(client: &SpotifyClient, command: &Command) -> CommandResponse {
+        if let Command::SetVolume(volume) = command {
+            match client.set_volume(*volume) {
+                Ok(()) => CommandResponse::success("Volume updated", None),
+                Err(e) => CommandResponse::error(format!("Failed to set volume: {}", e)),
+            }
+        } else {
+            CommandResponse::error("Invalid set volume command")
         }
     }
 }
@@ -28,13 +127,23 @@ impl CommandManager {
     }
 
     pub fn execute(&self, command: Command, client: &SpotifyClient) -> CommandResponse {
-        let args = CommandArgs {
-            data: serde_json::to_value(&command).unwrap_or_default(),
-        };
-
         match command {
-            Command::Pause => PauseCommandHandler::handle(client, args),
-            _ => CommandResponse::error("Command not implemented yet"),
+            Command::Play => PlayCommandHandler::handle(client, &command),
+            Command::PlayPause => PlayPauseCommandHandler::handle(client, &command),
+            Command::Pause => PauseCommandHandler::handle(client, &command),
+            Command::Prev => PrevCommandHandler::handle(client, &command),
+            Command::Next => NextCommandHandler::handle(client, &command),
+            Command::VolumeUp => VolumeUpCommandHandler::handle(client, &command),
+            Command::VolumeDown => VolumeDownCommandHandler::handle(client, &command),
+            Command::Shutdown => ShutdownCommandHandler::handle(client, &command),
+            Command::Shuffle(_) => ShuffleCommandHandler::handle(client, &command),
+            Command::Repeat(_) => RepeatCommandHandler::handle(client, &command),
+            Command::RepeatTrack(_) => RepeatTrackCommandHandler::handle(client, &command),
+            Command::Disconnect { .. } => DisconnectCommandHandler::handle(client, &command),
+            Command::SetPosition(_) => SetPositionCommandHandler::handle(client, &command),
+            Command::SetVolume(_) => SetVolumeCommandHandler::handle(client, &command),
+            Command::Activate => ActivateCommandHandler::handle(client, &command),
+            Command::CreateDevice { .. } => CommandResponse::error("CreateDevice command should be handled by the server"),
         }
     }
 } 

--- a/src/command_manager.rs
+++ b/src/command_manager.rs
@@ -20,6 +20,7 @@ impl CommandHandler for PauseCommandHandler {
     }
 }
 
+#[derive(Clone)]
 pub struct CommandManager;
 impl CommandManager {
     pub fn new() -> Self {

--- a/src/command_manager.rs
+++ b/src/command_manager.rs
@@ -1,0 +1,39 @@
+use crate::spotify::SpotifyClient;
+use crate::commands::{Command, CommandResponse};
+
+pub trait CommandHandler {
+    fn handle(client: &SpotifyClient, args: CommandArgs) -> CommandResponse;
+}
+
+#[derive(Debug)]
+pub struct CommandArgs {
+    pub data: serde_json::Value,
+}
+
+pub struct PauseCommandHandler;
+impl CommandHandler for PauseCommandHandler {
+    fn handle(client: &SpotifyClient, _args: CommandArgs) -> CommandResponse {
+        match client.pause() {
+            Ok(()) => CommandResponse::success("Playback paused", None),
+            Err(e) => CommandResponse::error(format!("Failed to pause: {}", e)),
+        }
+    }
+}
+
+pub struct CommandManager;
+impl CommandManager {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn execute(&self, command: Command, client: &SpotifyClient) -> CommandResponse {
+        let args = CommandArgs {
+            data: serde_json::to_value(&command).unwrap_or_default(),
+        };
+
+        match command {
+            Command::Pause => PauseCommandHandler::handle(client, args),
+            _ => CommandResponse::error("Command not implemented yet"),
+        }
+    }
+} 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,10 +1,18 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
+pub struct CommandMessage {
+    pub device_id: String,
+    pub command_type: String,
+    #[serde(default)]
+    pub params: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(tag = "type")]
 pub enum Command {
     Connect {
         token: String,
-        device_id: String,
         device_name: Option<String>,
     },
     Disconnect,
@@ -15,6 +23,42 @@ pub enum Command {
     Resume,
     Stop,
     GetCurrentTrack,
+}
+
+impl Command {
+    pub fn from_message(msg: CommandMessage) -> Result<(String, Command), String> {
+        let device_id = msg.device_id;
+        
+        let command = match msg.command_type.as_str() {
+            "connect" => {
+                let token = msg.params.get("token")
+                    .and_then(|v| v.as_str())
+                    .ok_or("Missing token parameter")?
+                    .to_string();
+                
+                let device_name = msg.params.get("device_name")
+                    .and_then(|v| v.as_str())
+                    .map(String::from);
+                
+                Command::Connect { token, device_name }
+            },
+            "play" => {
+                let track_id = msg.params.get("track_id")
+                    .and_then(|v| v.as_str())
+                    .ok_or("Missing track_id parameter")?
+                    .to_string();
+                
+                Command::Play { track_id }
+            },
+            "pause" => Command::Pause,
+            "resume" => Command::Resume,
+            "stop" => Command::Stop,
+            "get_current_track" => Command::GetCurrentTrack,
+            _ => return Err(format!("Unknown command type: {}", msg.command_type))
+        };
+
+        Ok((device_id, command))
+    }
 }
 
 #[derive(Debug, Serialize)]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,31 +1,20 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub enum Command {
     Connect {
         token: String,
         device_id: String,
         device_name: Option<String>,
     },
-    Disconnect {
-        device_id: String,
-    },
+    Disconnect,
     Play {
-        device_id: String,
         track_id: String,
     },
-    Pause {
-        device_id: String,
-    },
-    Resume {
-        device_id: String,
-    },
-    Stop {
-        device_id: String,
-    },
-    GetCurrentTrack {
-        device_id: String,
-    },
+    Pause,
+    Resume,
+    Stop,
+    GetCurrentTrack,
 }
 
 #[derive(Debug, Serialize)]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2,7 +2,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CommandMessage {
-    pub device_id: String,
+    #[serde(default)]
+    pub device_id: Option<String>,
     pub command_type: String,
     #[serde(default)]
     pub params: serde_json::Value,
@@ -11,7 +12,7 @@ pub struct CommandMessage {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(tag = "type")]
 pub enum Command {
-    Connect {
+    CreateDevice {
         token: String,
         device_name: Option<String>,
     },
@@ -27,10 +28,8 @@ pub enum Command {
 
 impl Command {
     pub fn from_message(msg: CommandMessage) -> Result<(String, Command), String> {
-        let device_id = msg.device_id;
-        
         let command = match msg.command_type.as_str() {
-            "connect" => {
+            "CreateDevice" => {
                 let token = msg.params.get("token")
                     .and_then(|v| v.as_str())
                     .ok_or("Missing token parameter")?
@@ -40,24 +39,33 @@ impl Command {
                     .and_then(|v| v.as_str())
                     .map(String::from);
                 
-                Command::Connect { token, device_name }
+                (String::new(), Command::CreateDevice { token, device_name })
             },
-            "play" => {
-                let track_id = msg.params.get("track_id")
-                    .and_then(|v| v.as_str())
-                    .ok_or("Missing track_id parameter")?
-                    .to_string();
+            cmd_type => {
+                let device_id = msg.device_id
+                    .ok_or("Device ID is required for this command")?;
                 
-                Command::Play { track_id }
-            },
-            "pause" => Command::Pause,
-            "resume" => Command::Resume,
-            "stop" => Command::Stop,
-            "get_current_track" => Command::GetCurrentTrack,
-            _ => return Err(format!("Unknown command type: {}", msg.command_type))
+                let command = match cmd_type {
+                    "play" => {
+                        let track_id = msg.params.get("track_id")
+                            .and_then(|v| v.as_str())
+                            .ok_or("Missing track_id parameter")?
+                            .to_string();
+                        
+                        Command::Play { track_id }
+                    },
+                    "pause" => Command::Pause,
+                    "resume" => Command::Resume,
+                    "stop" => Command::Stop,
+                    "get_current_track" => Command::GetCurrentTrack,
+                    _ => return Err(format!("Unknown command type: {}", cmd_type))
+                };
+                
+                (device_id, command)
+            }
         };
 
-        Ok((device_id, command))
+        Ok(command)
     }
 }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -49,9 +49,6 @@ impl Command {
                 (String::new(), Command::CreateDevice { token, device_name })
             },
             cmd_type => {
-                let device_id = msg.device_id
-                    .ok_or("Device ID is required for this command")?;
-                
                 let command = match cmd_type {
                     "Play" => Command::Play,
                     "PlayPause" => Command::PlayPause,
@@ -100,6 +97,9 @@ impl Command {
                     "Activate" => Command::Activate,
                     _ => return Err(format!("Unknown command type: {}", cmd_type))
                 };
+                
+                let device_id = msg.device_id
+                    .ok_or("Device ID is required for this command")?;
                 
                 (device_id, command)
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use log::info;
 
 mod commands;
+mod command_manager;
 mod server;
 mod spotify;
 mod ws_sink;

--- a/src/server.rs
+++ b/src/server.rs
@@ -12,13 +12,15 @@ use uuid::Uuid;
 use warp::ws::{Message, WebSocket};
 use warp::Filter;
 
+const PROTOCOL_VERSION: &str = "0.1.0";
+
 type Clients = Arc<Mutex<HashMap<String, Client>>>;
 pub type WsResult<T> = std::result::Result<T, warp::Error>;
 
 #[derive(Debug, serde::Serialize)]
 struct ConnectionResponse {
-    device_id: String,
-    message: String,
+    status: String,
+    protocol_version: String,
 }
 
 struct Client {
@@ -35,28 +37,39 @@ impl Client {
     }
 }
 
+struct ConnectionState {
+    devices: HashMap<String, SpotifyClient>,
+    sender: mpsc::UnboundedSender<WsResult<Message>>,
+}
+
+impl ConnectionState {
+    fn new(sender: mpsc::UnboundedSender<WsResult<Message>>) -> Self {
+        Self {
+            devices: HashMap::new(),
+            sender,
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct SpotifyServer {
-    clients: Clients,
     command_manager: CommandManager,
 }
 
 impl SpotifyServer {
     pub fn new() -> Self {
         Self {
-            clients: Arc::new(Mutex::new(HashMap::new())),
             command_manager: CommandManager::new(),
         }
     }
 
     pub async fn start(self, port: u16) {
-        let clients = self.clients.clone();
-
+        let server = self.clone();
         let ws_route = warp::path("ws")
             .and(warp::ws())
-            .and(with_clients(clients.clone()))
-            .map(|ws: warp::ws::Ws, clients| {
-                ws.on_upgrade(move |socket| Self::handle_client_connection(socket, clients))
+            .map(move |ws: warp::ws::Ws| {
+                let server = server.clone();
+                ws.on_upgrade(move |socket| server.handle_client_connection(socket))
             });
 
         let routes = ws_route.with(warp::cors().allow_any_origin());
@@ -64,9 +77,8 @@ impl SpotifyServer {
         warp::serve(routes).run(([127, 0, 0, 1], port)).await;
     }
 
-    async fn handle_client_connection(ws: WebSocket, clients: Clients) {
-        let device_id = Uuid::new_v4().to_string();
-        info!("New client connecting with generated device_id: {}", device_id);
+    async fn handle_client_connection(self, ws: WebSocket) {
+        info!("New client connecting");
 
         let (ws_sender, mut ws_receiver) = ws.split();
         let (tx, rx) = mpsc::unbounded_channel();
@@ -78,128 +90,85 @@ impl SpotifyServer {
             }
         }));
 
-        {
-            let mut clients = clients.lock().await;
-            clients.insert(device_id.clone(), Client::new(tx.clone()));
-        }
-
+        let connection_state = Arc::new(Mutex::new(ConnectionState::new(tx.clone())));
+        
         let connection_response = ConnectionResponse {
-            device_id: device_id.clone(),
-            message: "Connected to server. Use this device_id for future commands.".to_string(),
+            status: "Connected to server".to_string(),
+            protocol_version: PROTOCOL_VERSION.to_string(),
         };
         
         if let Ok(response_json) = serde_json::to_string(&connection_response) {
             if let Err(e) = tx.send(Ok(Message::text(response_json))) {
-                error!("Error sending initial device_id: {}", e);
+                error!("Error sending initial connection response: {}", e);
                 return;
             }
         }
-
-        let server = SpotifyServer { clients: clients.clone(), command_manager: CommandManager::new() };
         
         while let Some(result) = ws_receiver.next().await {
             let msg = match result {
                 Ok(msg) => msg,
                 Err(e) => {
-                    error!("Error receiving ws message for device_id {}: {}", device_id, e);
+                    error!("Error receiving ws message: {}", e);
                     break;
                 }
             };
 
             if let Ok(text) = msg.to_str() {
-                let command_message: CommandMessage = match serde_json::from_str(text) {
-                    Ok(msg) => msg,
-                    Err(e) => {
-                        error!("Error parsing command message: {}", e);
-                        continue;
-                    }
-                };
-
-                let (msg_device_id, command) = match Command::from_message(command_message) {
-                    Ok(result) => result,
-                    Err(e) => {
-                        let error_response = CommandResponse::error(e);
-                        if let Err(e) = tx.send(Ok(Message::text(serde_json::to_string(&error_response).unwrap()))) {
-                            error!("Error sending error response: {}", e);
-                        }
-                        continue;
-                    }
-                };
-
-                // Verify the device ID matches
-                if msg_device_id != device_id {
-                    let error_response = CommandResponse::error("Device ID mismatch");
-                    if let Err(e) = tx.send(Ok(Message::text(serde_json::to_string(&error_response).unwrap()))) {
-                        error!("Error sending error response: {}", e);
-                    }
-                    continue;
-                }
-
-                let response = {
-                    let mut clients = server.clients.lock().await;
-
-                    match command {
-                        Command::Connect { token, device_name } => {
-                            if let Some(client) = clients.get_mut(&device_id) {
-                                if client.spotify.is_some() {
-                                    CommandResponse::error("Device is already connected to Spotify")
-                                } else {
-                                    let mut spotify = SpotifyClient::new();
-                                    match spotify
-                                        .initialize(
-                                            &token,
-                                            device_name.unwrap_or_else(|| format!("Blockyspot {device_id}")),
-                                            client.sender.clone(),
-                                        )
-                                        .await
-                                    {
-                                        Ok(()) => {
-                                            client.spotify = Some(spotify);
-                                            CommandResponse::success("Connected to Spotify", None)
-                                        }
-                                        Err(e) => CommandResponse::error(format!("Failed to connect: {e}")),
-                                    }
-                                }
-                            } else {
-                                CommandResponse::error("Device not found")
-                            }
-                        }
-                        cmd => {
-                            if let Some(client) = clients.get_mut(&device_id) {
-                                if let Some(spotify) = &mut client.spotify {
-                                    server.command_manager.execute(cmd, spotify)
-                                } else {
-                                    CommandResponse::error("Device not connected to Spotify")
-                                }
-                            } else {
-                                CommandResponse::error("Device not found")
-                            }
-                        }
-                    }
-                };
-
-                let response_json = serde_json::to_string(&response).unwrap();
-                
-                if let Err(e) = tx.send(Ok(Message::text(response_json))) {
-                    error!("Error sending response: {}", e);
+                if let Err(e) = self.process_ws_message(text, &tx, connection_state.clone()).await {
+                    error!("Error processing message: {}", e);
                     break;
                 }
             }
         }
 
-        clients.lock().await.remove(&device_id);
-        info!("Client {} disconnected", device_id);
+        info!("Client disconnected");
     }
-}
 
-fn with_clients(clients: Clients) -> impl Filter<Extract = (Clients,), Error = Infallible> + Clone {
-    warp::any().map(move || clients.clone())
-}
+    async fn process_ws_message(
+        &self,
+        text: &str,
+        tx: &mpsc::UnboundedSender<WsResult<Message>>,
+        connection_state: Arc<Mutex<ConnectionState>>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let command_message: CommandMessage = serde_json::from_str(text)?;
 
-async fn broadcast_to_client(clients: &Clients, device_id: &str, message: &str) {
-    if let Some(client) = clients.lock().await.get(device_id) {
-        if let Err(e) = client.sender.send(Ok(Message::text(message))) {
-            error!("Error broadcasting to device {}: {}", device_id, e);
-        }
+        let response = {
+            let mut state = connection_state.lock().await;
+
+            match Command::from_message(command_message)? {
+                (_, Command::CreateDevice { token, device_name }) => {
+                    let device_id = Uuid::new_v4().to_string();
+                    let mut spotify = SpotifyClient::new();
+                    match spotify
+                        .initialize(
+                            &token,
+                            device_name.unwrap_or_else(|| format!("Blockyspot {device_id}")),
+                            tx.clone(),
+                        )
+                        .await
+                    {
+                        Ok(()) => {
+                            state.devices.insert(device_id.clone(), spotify);
+                            CommandResponse::success(
+                                "Connected to Spotify",
+                                Some(serde_json::json!({ "device_id": device_id }))
+                            )
+                        }
+                        Err(e) => CommandResponse::error(format!("Failed to connect: {e}")),
+                    }
+                }
+                (device_id, cmd) => {
+                    if let Some(spotify) = state.devices.get_mut(&device_id) {
+                        self.command_manager.execute(cmd, spotify)
+                    } else {
+                        CommandResponse::error("Device not found")
+                    }
+                }
+            }
+        };
+
+        let response_json = serde_json::to_string(&response)?;
+        tx.send(Ok(Message::text(response_json)))?;
+        Ok(())
     }
 }

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -165,9 +165,6 @@ impl SpotifyClient {
 
         let spirc = Arc::new(spirc);
 
-        // Queue the commands
-        spirc.activate()?;
-
         self.session = Some(session);
         self.player = Some(player);
         self.spirc = Some(spirc);

--- a/test_client.py
+++ b/test_client.py
@@ -163,9 +163,10 @@ async def main():
                         None, lambda: input("Enter device name (or press Enter for default): ").strip()
                     )
                     cmd = {
-                        "Connect": {
+                        "device_id": current_device_id,
+                        "command_type": "connect",
+                        "params": {
                             "token": token,
-                            "device_id": current_device_id,
                             "device_name": device_name if device_name else None
                         }
                     }
@@ -174,34 +175,35 @@ async def main():
                         None, lambda: input("Enter track ID (base62 format): ")
                     )
                     cmd = {
-                        "Play": {
-                            "device_id": current_device_id,
+                        "device_id": current_device_id,
+                        "command_type": "play",
+                        "params": {
                             "track_id": track_id
                         }
                     }
                 elif choice == '3':
                     cmd = {
-                        "Pause": {
-                            "device_id": current_device_id
-                        }
+                        "device_id": current_device_id,
+                        "command_type": "pause",
+                        "params": {}
                     }
                 elif choice == '4':
                     cmd = {
-                        "Resume": {
-                            "device_id": current_device_id
-                        }
+                        "device_id": current_device_id,
+                        "command_type": "resume",
+                        "params": {}
                     }
                 elif choice == '5':
                     cmd = {
-                        "Stop": {
-                            "device_id": current_device_id
-                        }
+                        "device_id": current_device_id,
+                        "command_type": "stop",
+                        "params": {}
                     }
                 elif choice == '6':
                     cmd = {
-                        "GetCurrentTrack": {
-                            "device_id": current_device_id
-                        }
+                        "device_id": current_device_id,
+                        "command_type": "get_current_track",
+                        "params": {}
                     }
                 elif choice == '7':
                     break


### PR DESCRIPTION
This PR adds a new command manager and removes almost all command responsability from the server. On top of that, almost all supported commands by Spirc were added, except for the `Load` command. This PR also makes big changes in the server structure as described in #2, to allow the right usage of these new commands.

# Changelog
- Added a command manager (305d7076246295d96b2f7161c998aec6984f4d81 & 8459e054f3f5eeddabf5cc6ae39ce23e25aa5da7)
- Modified connection logic and other server changes (See changelog in #2)
- Added the following commands (a0bb68cd0997ef95c18151c8308f25fdb5df81d5): 
  - **Play**: Resumes the playback. Does nothing if we are not the active device, or it isn't paused.
  - **PlayPause**: Resumes or pauses the playback. Does nothing if we are not the active device.
  - **Pause**: Pauses the playback. Does nothing if we are not the active device, or if it isn't playing.
  - **Prev**: Seeks to the beginning or skips to the previous track. Seeks to the beginning when the current track position is greater than 3 seconds. Does nothing if we are not the active device.
  - **Next**: Skips to the next track. Does nothing if we are not the active device.
  - **VolumeUp**: Increases the volume by configured steps of [ConnectConfig]. Does nothing if we are not the active device.
  - **VolumeDown**: Decreases the volume by configured steps of [ConnectConfig]. Does nothing if we are not the active device.
  - **Shutdown**: Safely shutdowns the spirc. This pauses the playback, disconnects the connect device and brings the future initially returned to an end.
  - **Shuffle**: Shuffles the playback according to the value. If true shuffles/reshuffles the playback. Otherwise, does nothing (if not shuffled) or unshuffles the playback while resuming at the position of the current track. Does nothing if we are not the active device.
  - **Repeat**: Repeats the playback context according to the value. Does nothing if we are not the active device.
  - **RepeatTrack**: Repeats the current track if true. Does nothing if we are not the active device. Skipping to the next track disables the repeating.
  - **Disconnect**: Disconnects the current device and pauses the playback according to the value. Does nothing if we are not the active device.
  - **SetPosition**: Updates the position to the given value. Does nothing if we are not the active device. If value is greater than the track duration, the update is ignored.
  - **SetVolume**: Updates the volume to the given value. Does nothing if we are not the active device.
  - **Activate**: Acquires the control as active connect device. Does nothing if we are not the active device.
 - Bug fixes related to error handling (See #6)