### PR TITLE
Make server port configurable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "blockyspot"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 authors = ["BlockySpot Team"]
 description = "A modifiable Spotify Connect client using librespot"
 
@@ -20,4 +20,5 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 futures = "0.3"
 uuid = { version = "1.4", features = ["v4"] } 
-base64 = "0.21" 
+base64 = "0.21"
+clap = { version = "4.0", features = ["derive"] } 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use clap::Parser;
 use log::info;
 
 mod commands;
@@ -9,14 +10,27 @@ mod ws_sink;
 
 use server::SpotifyServer;
 
+#[derive(Parser)]
+#[command(name = "blockyspot")]
+#[command(about = "A modifiable Spotify Connect client using librespot")]
+#[command(version = "0.1.0")]
+struct Args {
+    /// Port to run the WebSocket server on
+    #[arg(short, long, default_value_t = 8888)]
+    port: u16,
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     env_logger::init();
+    
+    let args = Args::parse();
+    
     info!("Starting BlockySpot...");
 
     let server = SpotifyServer::new();
-    info!("Starting WebSocket server on port 8888...");
-    server.start(8888).await;
+    info!("Starting WebSocket server on port {}...", args.port);
+    server.start(args.port).await;
 
     Ok(())
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,7 +4,7 @@ use crate::command_manager::CommandManager;
 use futures::{FutureExt, StreamExt};
 use log::{error, info};
 use std::collections::HashMap;
-use std::convert::Infallible;
+
 use std::sync::Arc;
 use tokio::sync::{mpsc, Mutex};
 use tokio_stream::wrappers::UnboundedReceiverStream;

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -89,7 +89,7 @@ impl SpotifyClient {
         let credentials = Credentials::with_access_token(token);
 
         let session = Session::new(session_config, Some(cache));
-        let mixer = mixer_builder(mixer_config);
+        let mixer = mixer_builder(mixer_config)?;
 
         let player = Player::new(
             player_config,
@@ -184,7 +184,7 @@ impl SpotifyClient {
             session.clone(),
             credentials,
             player.clone(),
-            mixer,
+            mixer.clone(),
         )
         .await?;
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add optional `-p` or `--port` command-line argument to configure the BlockySpot server's listening port.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR introduces the ability to specify the server port via command-line arguments, defaulting to 8888. During implementation, several compilation errors related to Rust edition and `Result` type handling in `spotify.rs` were encountered and resolved to ensure a successful build and integration of the new feature.